### PR TITLE
system language selection and KDE Plasma supplement pipewire-alsa package

### DIFF
--- a/.github/workflows/rootfs.yml
+++ b/.github/workflows/rootfs.yml
@@ -44,6 +44,22 @@ on:
         type: string
         default: 'xiaomi-sheng'
 
+      language:
+        description: 'System language'
+        type: choice
+        options:
+          - 'None (C.UTF-8)'
+          - 'en_US.UTF-8'
+          - 'zh_CN.UTF-8'
+          - 'zh_TW.UTF-8'
+          - 'ja_JP.UTF-8'
+          - 'ko_KR.UTF-8'
+          - 'de_DE.UTF-8'
+          - 'fr_FR.UTF-8'
+          - 'es_ES.UTF-8'
+          - 'ru_RU.UTF-8'
+        default: 'None (C.UTF-8)'
+
       boot_mode:
         description: |
           Boot mode:
@@ -1055,6 +1071,24 @@ jobs:
             echo "127.0.1.1 ${{ inputs.hostname }}" | sudo tee -a "$ROOTFS_MOUNT/etc/hosts"
           fi
           echo "✓ Hostname set to ${{ inputs.hostname }}"
+
+      - name: "Configure Locale"
+        run: |
+          LANG_CHOICE="${{ inputs.language }}"
+
+          if [ "$LANG_CHOICE" = 'None (C.UTF-8)' ]; then
+            echo "✓ System locale stays C.UTF-8"
+          else
+            # locales package provides locale-gen and /etc/locale.gen
+            sudo chroot "$ROOTFS_MOUNT" apt-get update
+            sudo chroot "$ROOTFS_MOUNT" apt-get install -y locales
+            # Generate selected language + en_US.UTF-8
+            sudo sed -i 's/^# *\(en_US\.UTF-8\)/\1/' "$ROOTFS_MOUNT/etc/locale.gen"
+            sudo sed -i "s/^# *\\(${LANG_CHOICE//./\\.}\\)/\\1/" "$ROOTFS_MOUNT/etc/locale.gen"
+            sudo chroot "$ROOTFS_MOUNT" locale-gen
+            echo "LANG=$LANG_CHOICE" | sudo tee "$ROOTFS_MOUNT/etc/default/locale"
+            echo "✓ Locale set to $LANG_CHOICE (+ en_US.UTF-8)"
+          fi
 
       - name: "Create User"
         run: |

--- a/.github/workflows/rootfs.yml
+++ b/.github/workflows/rootfs.yml
@@ -1139,7 +1139,8 @@ jobs:
           sudo chroot "$ROOTFS_MOUNT" apt-get install -y \
             "$PLASMA_PACKAGE" plasma-workspace plasma-nm \
             sddm konsole firefox-esr \
-            dolphin kate
+            dolphin kate \
+            pipewire-alsa
           echo "✓ KDE Plasma installed"
 
       - name: "Install KDE Plasma Plymouth Settings"


### PR DESCRIPTION
添加fcitx5和plasma屏幕键盘共存(仅限forky，trixie无该软件包)为可选项，修改参考项目 [GUF296/ubuntu-y700-build-ci](https://github.com/GUF296/ubuntu-y700-build-ci) 

添加系统语言选择(每个语言设置保留en_US为程序不支持当前语言时保留回退手段，如steam需要)

kde补充pipewire-alsa软件包解决部分软件的音频后端缺失部分组件会导致系统音频服务崩溃重启(如osu!lazer的音频后端缺失该软件包会导致系统音频服务重启且设备音频异常，重启设备才能恢复)